### PR TITLE
Add comparer options to EqualOpt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ go:
   - 1.10.x
   - 1.11
   - 1.12
-  - 1.13.x
-  - 1.14.x
+  - 1.13
+  - 1.14
+  - 1.15.x
 
 script:
     - go test -v -race -coverprofile=coverage.txt -covermode=atomic

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ go:
   - 1.12
   - 1.13
   - 1.14
-  - 1.15.x
+  - 1.15
+  - 1.16.x
 
 script:
     - go test -v -race -coverprofile=coverage.txt -covermode=atomic

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Framework to make tests easier to create, maintain and debug.
     - each test is self isolated so a panic won't stop other cases from running 
     - check for expected panic cases with `ShouldPanic`
   - Test error cases 
-    - Check that function returns an error: `ShouldErr`
+    - Check that a function returns an error: `ShouldErr`
     - Check that an error strings contains expected string: `ExpectedErr`
     - Check that an error is of expected type: `ExpectedErr: ErrType(err)`
   - Fail tests that take too long to complete
@@ -150,7 +150,7 @@ func TestDivide(t *testing.T) {
 // PASS: "divide by zero"
 ```
 
-## Compare Functions
+# Compare Functions
 used to compare two values to determine equality and displayed a detailed string describing any differences.
 
 ``` go
@@ -163,10 +163,18 @@ override the default
 trial.New(fn, cases).Comparer(myComparer).Test(t)
 ```
 
-### Equal
-This is the default comparer used, it is a wrapping for cmp.Equal with the AllowUnexported option set for all structs. This causes all fields (public and private) in a struct to be compared. (see https://github.com/google/go-cmp)
+## Equal
+The default comparer used, it is a wrapping for cmp.Equal with the AllowUnexported option set for all structs. This causes all fields (public and private) in a struct to be compared. (see https://github.com/google/go-cmp)
 
-### Contains ⊇
+### EqualOpt
+
+Customize the use of cmp.Equal with the following supported options: 
+  - `AllowAllUnexported` - compare all unexported (private) variables within a struct. This is useful when testing a struct inside its own package. This is the default behavior of **Equal**
+  - `IgnoreAllUnexported` - ignore all unexported (private) variables within a struct. This is useful when dealing with a struct outside the project. 
+  - `IgnoreFields(fields ...string)` - define a list of variables to exclude for the comparer, the field name are case sensitize and can be dot-delimited ("Field", "Parent.child")
+
+  
+## Contains ⊇
 
 Checks if the expected value is *contained* in the actual value. The symbol ⊇ is used to donate a subset. ∈ is used to show that a value exists in a slice. Contains checks the following relationships
 
@@ -182,7 +190,7 @@ Checks if the expected value is *contained* in the actual value. The symbol ⊇ 
   - is the expected map a subset of the actual map. all keys in expected are in actual and all values under that key are contained in actual
 
 ## Helper Functions
-The helper functions are convince methods for either ignoring errors on test setup or for capturing output for testing.
+The helper functions are convenience methods for either ignoring errors on test setup or for capturing output for testing.
 
 ### Output Capturing
   Capture output written to log, stdout or stderr.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Framework to make tests easier to create, maintain and debug.
 
+
+See [wiki](https://github.com/hydronica/trial/wiki) for tips and guides
 ## Philosophy
 
 - Tests should be written as [Table Driven Tests](https://github.com/golang/go/wiki/TableDrivenTests) with defined inputs and outputs
@@ -73,83 +75,6 @@ Alternatively to run as each case as a subtest
 
 ### Examples
 
-#### Test a simple add method
-
-``` go
-func Add(i1, i2 int) int {
-  return i1 + i2
-}
-
-func TestAdd(t *testing.T) {
-  testFn := func(in Input) (interface{}, error) {
-    return Add(in.Slice(0).Int(), in.Slice(1).Int()), nil
-  }
-  cases := trial.Cases{
-    "Add two numbers":{
-      Input: trial.Args(1,2),
-      Expected: 3,
-  }
-  trial.New(fn, cases).Test(t)
-  }
-
-  // Output: PASS: "Add two numbers"
-```
-
-#### Test string to int conversion
-
-``` go
-func TestStrconv_Itoa(t *testing.T)
-testFn := func(in Input) (interface{}, error) {
-    return strconv.Itoa(in.Int())
-}
-cases :=trial.Cases{
-  "valid int":{
-    Input: "12",
-    Expected: 12,
-  },
-  "invalid int": {
-    Input: "1abe",
-    ShouldErr: true,
-  },
-}
-trial.New(fn, cases).Test(t)
-}
-
-// Output: PASS: "valid int"
-// PASS: "invalid int"
-```
-
-#### Test divide method
-
-``` go
-func Divide(i1, i2 int) int {
-  return i1/i2
-}
-func TestDivide(t *testing.T) {
-  fn := func(in Input) (interface{}, error) {
-    return Divide(in.Slice(0).Int(), in.Slice(1).Int()), nil
-  }
-  cases := trial.Cases{
-    "1/1":{
-      Input: trial.Args(1,1),
-      Expected: 1,
-    },
-    "6/2": {
-      Input: trial.Args(6,2),
-      Expected: 1,
-    },
-    "divide by zero": {
-      Input: trial.Args(1,0),
-      ShouldPanic: true,
-    }
-  }
-  trial.New(fn, cases).Test(t)
-}
-// Output: PASS: "1/1"
-// FAIL: "6/2"
-// PASS: "divide by zero"
-```
-
 # Compare Functions
 used to compare two values to determine equality and displayed a detailed string describing any differences.
 
@@ -169,9 +94,12 @@ The default comparer used, it is a wrapping for cmp.Equal with the AllowUnexport
 ### EqualOpt
 
 Customize the use of cmp.Equal with the following supported options: 
-  - `AllowAllUnexported` - compare all unexported (private) variables within a struct. This is useful when testing a struct inside its own package. This is the default behavior of **Equal**
+  - `AllowAllUnexported` - **[default: Equal]** compare all unexported (private) variables within a struct. This is useful when testing a struct inside its own package. 
   - `IgnoreAllUnexported` - ignore all unexported (private) variables within a struct. This is useful when dealing with a struct outside the project. 
   - `IgnoreFields(fields ...string)` - define a list of variables to exclude for the comparer, the field name are case sensitize and can be dot-delimited ("Field", "Parent.child")
+  - `EquateEmpty`- **[default: Equal]** a nil map or slice is equal to an empty one (len is zero)
+  - `IgnoreTypes(values ...interface{})` - ignore all types of the values passed in. Ex: IgnoreTypes(int64(0), float32(0.0)) ignore int64 and float32
+  - `ApproxTime(d time.Duration)` - approximates time values to to the nearest duration. 
 
   
 ## Contains ⊇
@@ -188,64 +116,3 @@ Checks if the expected value is *contained* in the actual value. The symbol ⊇ 
   - is the expected slice a subset of the actual slice. all values in expected exist and are contained in actual.
 - **map[key]interface{} ⊇ map[key]interface{}**
   - is the expected map a subset of the actual map. all keys in expected are in actual and all values under that key are contained in actual
-
-## Helper Functions
-The helper functions are convenience methods for either ignoring errors on test setup or for capturing output for testing.
-
-### Output Capturing
-  Capture output written to log, stdout or stderr.
-  Call *ReadAll* to get captured data as a single string.
-  Call *ReadLines* to get captured data as a []string split by newline. Calling either method closes and reset the output redirection.
-
-#### CaptureLog
-
-``` go
-  c := CaptureLog()
-  // logic that writes to logs
-  log.Print("hello")
-  c.ReadAll() // -> returns hello
-```
-
-Note: log is reset to write to stderr
-
-#### CaptureStdErr
-
-``` go
-  c := CaptureStdErr()
-  // write to stderr
-  fmt.Fprint(os.stderr, "hello\n")
-  fmt.Fprint(os.stderr, "world")
-  c.ReadLines() // []string{"hello","world"}
-```
-
-#### CaptureStdOut
-
-``` go
-  c := CaptureStdOut()
-  // write to stdout
-  fmt.Println("hello")
-  fmt.Print("world")
-  c.ReadLines() // []string{"hello","world"}
-```
-
-### Time Parsing
-
-convenience functions for getting a time value to test, methods panic instead of error
-
-- **TimeHour(s string)** - uses format "2006-01-02T15"
-- **TimeDay(s string)** - uses format "2006-01-02"
-- **Times(layout string, values ...string)**
-- **TimeP(layout string, s string)** returns a *time.Time
-
-### Pointer init
-
-convenience functions for initializing a pointer to a basic type
-
-- int pointer
-  - IntP, Int8P, Int16P, Int32P, Int64P
-- uint pointer
-  - UintP, Uint8P, Uint16P, Uint32P, Uint64P
-- bool pointer - BoolP
-- float pointer
-  - Float32P, Float64P
-- string pointer - StringP

--- a/functions.go
+++ b/functions.go
@@ -25,6 +25,23 @@ func Contains(x, y interface{}) (bool, string) {
 	return false, r.String()
 }
 
+const (
+	SubStrings = iota
+	SubSlices
+	SubMaps
+)
+
+// ContainsOpt allow configurable options to the contains method
+// 1. Check for sub-strings ("abc" -> "abcdefg")
+// 2. Check for sub-slices (["a"] -> ["a","b","c"])
+// 3. Check for sub-maps
+// 4. use regex match as a sub-string check
+/*
+func ContainsOpt(o interface{}) CompareFunc {
+	return Contains
+}
+*/
+
 func contains(x, y interface{}) differ {
 	valX := reflect.ValueOf(x)
 	valY := reflect.ValueOf(y)
@@ -163,6 +180,13 @@ func AllowAllUnexported(i interface{}) cmp.Option {
 // IgnoreAllUnexported sets cmp.Diff to ignore all unexported (private) variables
 func IgnoreAllUnexported(i interface{}) cmp.Option {
 	return cmpopts.IgnoreUnexported(findAllStructs(i)...)
+}
+
+// IgnoreFields is a wrapper around the cmpopts.IgnoreFields
+func IgnoreFields(f ...string) func(interface{}) cmp.Option {
+	return func(i interface{}) cmp.Option {
+		return cmpopts.IgnoreFields(i, f...)
+	}
 }
 
 func findAllStructs(i interface{}) []interface{} {

--- a/functions_test.go
+++ b/functions_test.go
@@ -122,7 +122,11 @@ func TestComparerOptions(t *testing.T) {
 		pString string
 		Child   child
 		kid     child
+
+		Map   map[string]interface{}
+		Slice []string
 	}
+	type Alias int
 
 	type input struct {
 		fn CompareFunc
@@ -188,6 +192,58 @@ func TestComparerOptions(t *testing.T) {
 				fn: EqualOpt(IgnoreAllUnexported, IgnoreFields("Child")),
 				v1: tStruct{Int: 1, String: "ello", Child: child{Float: 12.34}},
 				v2: tStruct{Int: 1, String: "ello"},
+			},
+			Expected: true,
+		},
+		"Equate Empty": {
+			Input: input{
+				fn: EqualOpt(IgnoreAllUnexported, EquateEmpty),
+				v1: tStruct{Map: map[string]interface{}{}, Slice: []string{}},
+				v2: tStruct{Map: nil, Slice: nil},
+			},
+			Expected: true,
+		},
+		"IgnoreType": {
+			Input: input{
+				fn: EqualOpt(IgnoreAllUnexported, IgnoreTypes(int(10))),
+				v1: tStruct{Int: 10, String: "ello"},
+				v2: tStruct{String: "ello"},
+			},
+			Expected: true,
+		},
+		"IgnoreAlias": {
+			Input: input{
+				fn: EqualOpt(IgnoreAllUnexported, IgnoreTypes(Alias(0))),
+				v1: struct {
+					A   Alias
+					Int int
+				}{A: 10, Int: 7},
+				v2: struct {
+					A   Alias
+					Int int
+				}{Int: 7},
+			},
+			Expected: true,
+		},
+		"IgnoreKeepAlias": {
+			Input: input{
+				fn: EqualOpt(IgnoreAllUnexported, IgnoreTypes(int(0))),
+				v1: struct {
+					A   Alias
+					Int int
+				}{A: 10, Int: 7},
+				v2: struct {
+					A   Alias
+					Int int
+				}{A: 10},
+			},
+			Expected: true,
+		},
+		"ApproxTime": {
+			Input: input{
+				fn: EqualOpt(ApproxTime(time.Minute)),
+				v1: struct{ T time.Time }{T: Time(time.RFC3339, "2020-10-05T12:14:17Z")},
+				v2: struct{ T time.Time }{T: Time(time.RFC3339, "2020-10-05T12:14:18Z")},
 			},
 			Expected: true,
 		},

--- a/functions_test.go
+++ b/functions_test.go
@@ -111,7 +111,7 @@ func TestEqualFn(t *testing.T) {
 
 func TestContainsFn(t *testing.T) {
 	New(func(in Input) (interface{}, error) {
-		b, s := ContainsFn(in.Slice(0).Interface(), in.Slice(1).Interface())
+		b, s := Contains(in.Slice(0).Interface(), in.Slice(1).Interface())
 		var err error
 		if s != "" {
 			err = errors.New(s)
@@ -268,8 +268,8 @@ func TestCmpFuncs(t *testing.T) {
 			Expected: "",
 		},
 		"non-identical functions": {
-			Input:    Args(Equal, ContainsFn),
+			Input:    Args(Equal, Contains),
 			Expected: "funcs not equal",
 		},
-	}).EqualFn(ContainsFn).Test(t)
+	}).EqualFn(Contains).Test(t)
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/hydronica/trial
 
 go 1.13
 
-require github.com/google/go-cmp v0.5.4 // indirect
+require github.com/google/go-cmp v0.5.5

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/hydronica/trial
 
 go 1.13
 
-require github.com/google/go-cmp v0.4.1
+require github.com/google/go-cmp v0.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
-github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,4 @@
-github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
-github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
-github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
-github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/options.go
+++ b/options.go
@@ -1,5 +1,0 @@
-package trial
-
-type Options interface {
-	set(o *ComparerOption) bool
-}

--- a/options.go
+++ b/options.go
@@ -1,0 +1,5 @@
+package trial
+
+type Options interface {
+	set(o *ComparerOption) bool
+}


### PR DESCRIPTION
The Purpose of this PR is to add more flexibility to how trial uses the underlying cmp.Equal function. Cmp.Equal supports a bunch of options, but they are not very clear to someone that hasn't used them exclusively. Trial has tried to simplify these options by hiding them by default. But there are valid use-cases where the user wants to customize how the cmp.Equal function works without having to learn the inner of the go-cmp package and write their own comparer function. 

Step 1: Decide which approach to take 

``` go 
// normal trial usage
trial.New(fn, cases).Comparer(trial.Equal).Test(t)
```

### 1 - Add option to builder
``` go 
// Ignore unexported/private variables 
trial.New(fn, cases).Options(trial.IgnoreUnexported()).Comparer(trial.Equal).Test(t)

// Only compare on select fields 
trial.New(fn,cases).
    Options(trial.Fields("Struct.Name","Struct.Value").
    Comparer(trial.Equal).
   Test(t)
```

### 2 - Option Config Struct 
``` go 
// Ignore unexported/private variables 
opt := trial.ComparerOption{ IgnorePrivates: true}
trial.New(fn,cases).Comparer(opt.Equal).Test(t)

// only compare on select fields 
opt := trial.ComparerOption{
  Fields: []string{"Struct.Name","Struct.Value"},
  }
trial.New(fn,cases).Comparer(opt.Equal).Test(t)
```

### 3 - Functional Approach 
``` go
// Ignore unexported/private variables 
trial.New(fn,cases).
  Comparer(trial.EqualWithOptions(trial.IgnorePrivate)).
  Test(t)

// only compare on select fields 
trial.New(fn,cases).
  Comparer(trial.EqualWithOptions(trial.Fields("Struct.Name","Struct.Value")).
  Test(t)