### PR TITLE
Bug fix for struct recursion using maps

### DIFF
--- a/functions_test.go
+++ b/functions_test.go
@@ -478,12 +478,16 @@ func TestFindAllStructs(t *testing.T) {
 	type tStruct struct {
 		Apple int
 	}
+	type recurse struct {
+		A *recurse
+		B map[string]recurse
+	}
 	type mapper struct {
 		m map[string]tStruct
 	}
 	fn := func(in any) ([]string, error) {
 		result := make([]string, 0)
-		for _, v := range findAllStructs(in) {
+		for _, v := range findAllStructs(in, nil) {
 			s := reflect.TypeOf(v).Name()
 			result = append(result, s)
 		}
@@ -502,6 +506,10 @@ func TestFindAllStructs(t *testing.T) {
 		"*mapper": {
 			Input:    &mapper{},
 			Expected: []string{"mapper", "tStruct"},
+		},
+		"self ref": {
+			Input:    recurse{A: &recurse{}},
+			Expected: []string{"recurse"},
 		},
 	}
 	New(fn, cases).SubTest(t)


### PR DESCRIPTION
the helper methods used with the cmp.Options run into infinite recursive for a struct with a reference to itself using a map. 
``` go 
Type Recurser struct {
   Myself map[string]Recurser
}
```
This adds a map that tracks added values to stop the recursion and avoid duplicate structs being added. 
