### PR TITLE
Add JSONEqual semantic comparer

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Customize the use of cmp.Equal with the following supported options:
   - `IgnoreAllUnexported` - ignore all unexported (private) variables within a struct. This is useful when dealing with a struct outside the project. 
   - `IgnoreFields(fields ...string)` - define a list of variables to exclude for the comparer, the field names are case sensitive and can be dot-delimited ("Field", "Parent.child")
   - `EquateEmpty`- **[default: Equal]** a nil map or slice is equal to an empty one (len is zero)
-  - `IgnoreTypes(values ...interface{})` - ignore all types of the values passed in. Ex: IgnoreTypes(int64(0), float32(0.0)) ignore int64 and float32
+  - `IgnoreTypes(values ...any)` - ignore all types of the values passed in. Ex: IgnoreTypes(int64(0), float32(0.0)) ignore int64 and float32
   - `ApproxTime(d time.Duration)` - approximates time values to the nearest duration. 
 
 ```go
@@ -173,6 +173,6 @@ Checks if the expected value is *contained* in the actual value. The symbol ⊇ 
 
 - **string ⊇ string** - is the expected string contained in the actual string (strings.Contains)
 - **string ⊇ []string** - are the expected substrings contained in the actual string
-- **[]interface{} ⊇ interface{}** - is the expected value found in the slice or array
-- **[]interface{} ⊇ []interface{}** - is the expected slice a subset of the actual slice. all values in expected exist and are contained in actual.
-- **map[key]interface{} ⊇ map[key]interface{}** - is the expected map a subset of the actual map. all keys in expected are in actual and all values under that key are contained in actual
+- **[]any ⊇ any** - is the expected value found in the slice or array
+- **[]any ⊇ []any** - is the expected slice a subset of the actual slice. all values in expected exist and are contained in actual.
+- **map[key]any ⊇ map[key]any** - is the expected map a subset of the actual map. all keys in expected are in actual and all values under that key are contained in actual

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,7 +24,7 @@ type Case[In any, Out any] struct {
 type Input struct { /* ... */ }
 
 // Custom comparer signature
-type CompareFunc func(actual, expected interface{}) (equal bool, differences string)
+type CompareFunc func(actual, expected any) (equal bool, differences string)
 ```
 
 ## Core Functions
@@ -71,7 +71,7 @@ For use with `trial.Args()`. See [helpers.md](helpers.md#input-helpers) for deta
 | `Bool()` | `bool` | Get as bool |
 | `Slice(i)` | `Input` | Get element at index |
 | `Map(key)` | `Input` | Get value for key |
-| `Interface()` | `interface{}` | Get raw value |
+| `Interface()` | `any` | Get raw value |
 
 ## Comparers
 
@@ -80,6 +80,7 @@ See [comparers.md](comparers.md) for detailed documentation.
 | Comparer | Description |
 |----------|-------------|
 | `Equal` | Default. Strict equality via `cmp.Equal` |
+| `JSONEqual` | Semantic JSON comparison (key order, whitespace) |
 | `Contains` | Subset/substring matching |
 | `EqualOpt(opts...)` | Customizable equality |
 | `CmpFuncs` | Compare function pointers |

--- a/docs/comparers.md
+++ b/docs/comparers.md
@@ -7,6 +7,7 @@ Comparers determine how trial checks equality between actual and expected values
 - [Overview](#overview)
 - [Equal (Default)](#equal-default)
 - [EqualOpt](#equalopt)
+- [JSONEqual](#jsonequal)
 - [Contains](#contains)
 - [CmpFuncs](#cmpfuncs)
 - [Custom Comparers](#custom-comparers)
@@ -18,7 +19,7 @@ Comparers determine how trial checks equality between actual and expected values
 A comparer is a function with this signature:
 
 ```go
-type CompareFunc func(actual, expected interface{}) (equal bool, differences string)
+type CompareFunc func(actual, expected any) (equal bool, differences string)
 ```
 
 - `equal` - Returns `true` if values match
@@ -40,7 +41,7 @@ The default comparer. Wraps `cmp.Equal` from [google/go-cmp](https://github.com/
 - **EquateEmpty** - Treats `nil` and empty slices/maps as equal
 
 ```go
-func Equal(actual, expected interface{}) (bool, string)
+func Equal(actual, expected any) (bool, string)
 ```
 
 **When to use:** Most cases. Strict equality checking.
@@ -61,7 +62,7 @@ trial.New(fn, cases).Comparer(trial.Equal).Test(t)
 Customizable equality comparer. Build your own comparison logic by combining options.
 
 ```go
-func EqualOpt(optFns ...func(i interface{}) cmp.Option) func(actual, expected interface{}) (bool, string)
+func EqualOpt(optFns ...func(i any) cmp.Option) func(actual, expected any) (bool, string)
 ```
 
 ### Available Options
@@ -91,7 +92,7 @@ trial.EqualOpt(trial.IgnoreAllUnexported)
 Exclude specific fields from comparison by name.
 
 ```go
-func IgnoreFields(f ...string) func(interface{}) cmp.Option
+func IgnoreFields(f ...string) func(any) cmp.Option
 ```
 
 - Field names are **case-sensitive**
@@ -110,7 +111,7 @@ trial.EqualOpt(
 Ignore specific fields on a given struct type. Use this when ignoring fields in embedded structs where `IgnoreFields` cannot infer the correct type.
 
 ```go
-func IgnoreFieldsOf(structType interface{}, fields ...string) func(interface{}) cmp.Option
+func IgnoreFieldsOf(structType any, fields ...string) func(any) cmp.Option
 ```
 
 ```go
@@ -141,7 +142,7 @@ trial.New(fn, cases).Comparer(
 Ignore all values of specified types.
 
 ```go
-func IgnoreTypes(types ...interface{}) func(interface{}) cmp.Option
+func IgnoreTypes(types ...any) func(any) cmp.Option
 ```
 
 ```go
@@ -157,7 +158,7 @@ trial.EqualOpt(
 Consider time values equal if they differ by less than the specified duration.
 
 ```go
-func ApproxTime(d time.Duration) func(interface{}) cmp.Option
+func ApproxTime(d time.Duration) func(any) cmp.Option
 ```
 
 ```go
@@ -201,12 +202,68 @@ trial.New(fn, cases).Comparer(
 
 ---
 
+## JSONEqual
+
+Semantic JSON comparison. Normalizes both sides to JSON DOM shape before comparing with `cmp.Diff`. Ignores key ordering and whitespace differences.
+
+```go
+func JSONEqual(actual, expected any) (bool, string)
+```
+
+**When to use:** Comparing struct output to embedded JSON fixtures, API response bodies, or JSON strings that differ only in formatting.
+
+**Accepted shapes on either side:**
+
+| Input | Normalization |
+|-------|---------------|
+| `string` | `json.Unmarshal` (inline, embedded, or API body) |
+| `[]byte`, `json.RawMessage` | `json.Unmarshal` |
+| struct, map, slice, pointer | `json.Marshal` → `json.Unmarshal` |
+
+**Recommended fixture pattern** — load golden JSON with `//go:embed`, pass as `Expected`:
+
+```go
+//go:embed testdata/expected.json
+var expectedJSON string
+
+cases := trial.Cases[Input, string]{
+    "valid response": {Input: someInput, Expected: expectedJSON},
+}
+trial.New(fn, cases).Comparer(trial.JSONEqual).SubTest(t)
+```
+
+**Struct vs JSON string:**
+
+```go
+type Response struct {
+    Name  string `json:"name"`
+    Count int    `json:"count"`
+}
+
+cases := trial.Cases[Input, string]{
+    "matches golden": {
+        Input:    in,
+        Expected: `{"count":5,"name":"foo"}`, // key order differs from struct
+    },
+}
+// fn returns Response; JSONEqual compares semantically
+trial.New(fn, cases).Comparer(trial.JSONEqual).SubTest(t)
+```
+
+**Limitations:**
+
+- JSON numbers become `float64` after normalization (standard Go JSON behavior)
+- Unexported struct fields are not compared (JSON round-trip uses exported fields only)
+- Invalid JSON returns an error naming the side with parse detail (e.g. `actual: invalid JSON: invalid character 'n' ...`)
+
+---
+
 ## Contains
 
 Subset matching comparer. Checks if the expected value is **contained in** the actual value.
 
 ```go
-func Contains(x, y interface{}) (bool, string)
+func Contains(x, y any) (bool, string)
 ```
 
 ### Symbols
@@ -290,7 +347,7 @@ func TestContains(t *testing.T) {
 Compares two function values to determine if they point to the same function.
 
 ```go
-func CmpFuncs(x, y interface{}) (b bool, s string)
+func CmpFuncs(x, y any) (b bool, s string)
 ```
 
 **Note:** Due to Go's function comparison limitations, this compares function pointers, not function behavior.
@@ -321,13 +378,13 @@ Create your own comparer for specialized comparison logic.
 ### Signature
 
 ```go
-func MyComparer(actual, expected interface{}) (bool, string)
+func MyComparer(actual, expected any) (bool, string)
 ```
 
 ### Example: Fuzzy String Matching
 
 ```go
-func FuzzyMatch(actual, expected interface{}) (bool, string) {
+func FuzzyMatch(actual, expected any) (bool, string) {
     a, ok1 := actual.(string)
     e, ok2 := expected.(string)
     if !ok1 || !ok2 {
@@ -352,7 +409,7 @@ trial.New(fn, cases).Comparer(FuzzyMatch).Test(t)
 
 ```go
 func WithinTolerance(tolerance float64) trial.CompareFunc {
-    return func(actual, expected interface{}) (bool, string) {
+    return func(actual, expected any) (bool, string) {
         a, ok1 := actual.(float64)
         e, ok2 := expected.(float64)
         if !ok1 || !ok2 {
@@ -378,6 +435,7 @@ trial.New(fn, cases).Comparer(WithinTolerance(0.001)).Test(t)
 | Scenario | Recommended Comparer |
 |----------|---------------------|
 | Exact equality (default) | `Equal` |
+| JSON / struct semantic equality | `JSONEqual` |
 | Ignore specific fields | `EqualOpt(IgnoreFields(...))` |
 | Ignore embedded struct fields | `EqualOpt(IgnoreFieldsOf(EmbeddedType{}, ...))` |
 | Ignore private fields | `EqualOpt(IgnoreAllUnexported)` |

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -19,7 +19,7 @@ Trial provides helper functions to simplify test setup.
 Converts multiple arguments into an `Input` value.
 
 ```go
-func Args(args ...interface{}) Input
+func Args(args ...any) Input
 ```
 
 **Example:**
@@ -47,8 +47,8 @@ cases := trial.Cases[trial.Input, int]{
 | `Float64()` | `float64` | Get as float64 (parses strings) |
 | `Bool()` | `bool` | Get as bool (parses strings) |
 | `Slice(i int)` | `Input` | Get element at index |
-| `Map(key interface{})` | `Input` | Get value for key |
-| `Interface()` | `interface{}` | Get raw value |
+| `Map(key any)` | `Input` | Get value for key |
+| `Interface()` | `any` | Get raw value |
 
 ---
 

--- a/functions.go
+++ b/functions.go
@@ -1,6 +1,7 @@
 package trial
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
@@ -15,7 +16,7 @@ import (
 // x is a string -> y is a string that is equal to or a subset of x (string.Contains)
 // x is a slice or array -> y is contained in x
 // x is a map -> y is a map and is contained in x
-func Contains(x, y interface{}) (bool, string) {
+func Contains(x, y any) (bool, string) {
 	// if nothing is expected we have a match
 	if y == nil {
 		return true, ""
@@ -39,12 +40,12 @@ func Contains(x, y interface{}) (bool, string) {
 // 3. Check for sub-maps
 // 4. use regex match as a sub-string check
 /*
-func ContainsOpt(o interface{}) CompareFunc {
+func ContainsOpt(o any) CompareFunc {
 	return Contains
 }
 */
 
-func contains(x, y interface{}) differ {
+func contains(x, y any) differ {
 	valX := reflect.ValueOf(x)
 	valY := reflect.ValueOf(y)
 	switch valX.Kind() {
@@ -59,7 +60,7 @@ func contains(x, y interface{}) differ {
 					return newMessagef("type mismatch %T %T", x, y)
 				}
 				v := []string{valX.String()}
-				arrI := make([]interface{}, len(arr))
+				arrI := make([]any, len(arr))
 				for i, v := range arr {
 					arrI[i] = v
 				}
@@ -73,7 +74,7 @@ func contains(x, y interface{}) differ {
 		return newDiff(x, s)
 	case reflect.Array, reflect.Slice:
 		if valY.Kind() == reflect.Slice || valY.Kind() == reflect.Array {
-			child := make([]interface{}, valY.Len())
+			child := make([]any, valY.Len())
 			for i := 0; i < valY.Len(); i++ {
 				child[i] = valY.Index(i).Interface()
 			}
@@ -104,7 +105,7 @@ func contains(x, y interface{}) differ {
 }
 
 func isInMap(parent reflect.Value, child reflect.Value) differ {
-	d := &mapDiff{values: make(map[interface{}][]string, 0)}
+	d := &mapDiff{values: make(map[any][]string, 0)}
 	for _, key := range child.MapKeys() {
 		p := parent.MapIndex(key)
 		if !p.IsValid() {
@@ -119,10 +120,10 @@ func isInMap(parent reflect.Value, child reflect.Value) differ {
 	return d.diffOrNil()
 }
 
-func isInSlice(parent reflect.Value, child ...interface{}) differ {
+func isInSlice(parent reflect.Value, child ...any) differ {
 	c := &collection{
-		found:   make([]interface{}, 0),
-		missing: make([]interface{}, 0),
+		found:   make([]any, 0),
+		missing: make([]any, 0),
 	}
 	for _, v := range child {
 		found := false
@@ -146,15 +147,68 @@ func isInSlice(parent reflect.Value, child ...interface{}) differ {
 
 // Equal use the cmp.Diff method to check equality and display differences.
 // This method checks all unexpected values
-func Equal(actual, expected interface{}) (bool, string) {
+func Equal(actual, expected any) (bool, string) {
 	fn := EqualOpt(AllowAllUnexported, EquateEmpty)
 	return fn(actual, expected)
 }
 
+// JSONEqual compares actual and expected semantically as JSON.
+// Strings and []byte are unmarshaled; other values are marshaled then unmarshaled
+// so both sides share the same JSON DOM shape (map, slice, float64 numbers).
+// Use with embedded fixture strings or struct outputs that differ only in key order or formatting.
+func JSONEqual(actual, expected any) (bool, string) {
+	actualNorm, err := normalizeToJSON(actual)
+	if err != nil {
+		return false, fmt.Sprintf("actual: invalid JSON: %v", err)
+	}
+	expectedNorm, err := normalizeToJSON(expected)
+	if err != nil {
+		return false, fmt.Sprintf("expected: invalid JSON: %v", err)
+	}
+	r := cmp.Diff(actualNorm, expectedNorm)
+	return r == "", r
+}
+
+func normalizeToJSON(v any) (any, error) {
+	if v == nil {
+		return nil, nil
+	}
+	switch x := v.(type) {
+	case string:
+		var out any
+		if err := json.Unmarshal([]byte(x), &out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	case []byte:
+		var out any
+		if err := json.Unmarshal(x, &out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	case json.RawMessage:
+		var out any
+		if err := json.Unmarshal(x, &out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	default:
+		data, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		var out any
+		if err := json.Unmarshal(data, &out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+}
+
 // EqualOpt allow easy customization of the cmp.Equal method.
 // see below for a list of supported options
-func EqualOpt(optFns ...func(i interface{}) cmp.Option) func(actual, expected interface{}) (bool, string) {
-	return func(actual, expected interface{}) (bool, string) {
+func EqualOpt(optFns ...func(i any) cmp.Option) func(actual, expected any) (bool, string) {
+	return func(actual, expected any) (bool, string) {
 		opts := make([]cmp.Option, 0)
 		for _, fn := range optFns {
 			opts = append(opts, fn(actual))
@@ -166,19 +220,19 @@ func EqualOpt(optFns ...func(i interface{}) cmp.Option) func(actual, expected in
 }
 
 // AllowAllUnexported sets cmp.Diff to allow all unexported (private) variables
-func AllowAllUnexported(i interface{}) cmp.Option {
+func AllowAllUnexported(i any) cmp.Option {
 	return cmp.AllowUnexported(findAllStructs(i, nil)...)
 }
 
 // IgnoreAllUnexported sets cmp.Diff to ignore all unexported (private) variables
-func IgnoreAllUnexported(i interface{}) cmp.Option {
+func IgnoreAllUnexported(i any) cmp.Option {
 	return cmpopts.IgnoreUnexported(findAllStructs(i, nil)...)
 }
 
 // IgnoreFields is a wrapper around the cmpopts.IgnoreFields
 // syntax: IgnoreFields(package.struct.Field)
-func IgnoreFields(f ...string) func(interface{}) cmp.Option {
-	return func(i interface{}) cmp.Option {
+func IgnoreFields(f ...string) func(any) cmp.Option {
+	return func(i any) cmp.Option {
 		t := reflect.TypeOf(i)
 		if t.Kind() == reflect.Ptr { // dereference pointers
 			i = reflect.New(t.Elem()).Elem().Interface()
@@ -196,8 +250,8 @@ func IgnoreFields(f ...string) func(interface{}) cmp.Option {
 // cannot infer the correct type.
 //
 //	trial.EqualOpt(trial.IgnoreFieldsOf(Metadata{}, "CreatedAt", "UpdatedAt"))
-func IgnoreFieldsOf(structType interface{}, fields ...string) func(interface{}) cmp.Option {
-	return func(_ interface{}) cmp.Option {
+func IgnoreFieldsOf(structType any, fields ...string) func(any) cmp.Option {
+	return func(_ any) cmp.Option {
 		return cmpopts.IgnoreFields(structType, fields...)
 	}
 }
@@ -205,8 +259,8 @@ func IgnoreFieldsOf(structType interface{}, fields ...string) func(interface{}) 
 // IgnoreTypes is a wrapper around the cmpopts.IgnoreTypes
 // it allows ignore the type of the values passed in
 // int32(0), int(0), string(0), time.Duration(0), etc
-func IgnoreTypes(types ...interface{}) func(interface{}) cmp.Option {
-	return func(_ interface{}) cmp.Option {
+func IgnoreTypes(types ...any) func(any) cmp.Option {
+	return func(_ any) cmp.Option {
 		return cmpopts.IgnoreTypes(types...)
 	}
 }
@@ -214,15 +268,15 @@ func IgnoreTypes(types ...interface{}) func(interface{}) cmp.Option {
 // ApproxTime is a wrapper around the cmpopts.EquateApproxTime
 // it will consider time.Time values equal if there difference is
 // less than the defined duration
-func ApproxTime(d time.Duration) func(interface{}) cmp.Option {
-	return func(_ interface{}) cmp.Option {
+func ApproxTime(d time.Duration) func(any) cmp.Option {
+	return func(_ any) cmp.Option {
 		return cmpopts.EquateApproxTime(d)
 	}
 }
 
 /*
-func IgnoreInterfaces(i ...interface{}) func(interface{}) cmp.Option {
-	return func(i interface{}) cmp.Option {
+func IgnoreInterfaces(i ...any) func(any) cmp.Option {
+	return func(i any) cmp.Option {
 		return cmpopts.IgnoreInterfaces(i)
 	}
 }
@@ -231,7 +285,7 @@ func IgnoreInterfaces(i ...interface{}) func(interface{}) cmp.Option {
 // EquateEmpty is a wrapper around cmpopts.EquateEmpty
 // it determines all maps and slices with a length of zero to be equal,
 // regardless of whether they are nil
-func EquateEmpty(i interface{}) cmp.Option {
+func EquateEmpty(i any) cmp.Option {
 	return cmpopts.EquateEmpty()
 }
 
@@ -300,7 +354,7 @@ func findAllStructs(i any, structs structMap) []any {
 			}
 			if !v.CanInterface() {
 				// if the field is unexported (private) we wouldn't be able
-				// to get the interface{} so instead create a copy of that field
+				// to get the any so instead create a copy of that field
 				v = reflect.New(v.Type()).Elem()
 			}
 			structs.Add(findAllStructs(v.Interface(), structs)...)
@@ -339,7 +393,7 @@ func findAllStructs(i any, structs structMap) []any {
 }
 
 // CmpFuncs tries to determine if x is the same function as y.
-func CmpFuncs(x, y interface{}) (b bool, s string) {
+func CmpFuncs(x, y any) (b bool, s string) {
 	if x == nil || y == nil {
 		if x == y {
 			return true, ""
@@ -368,14 +422,14 @@ type differ interface {
 type message string
 
 func (m message) String() string { return string(m) }
-func newMessagef(s string, args ...interface{}) message {
+func newMessagef(s string, args ...any) message {
 	return message(fmt.Sprintf(s, args...))
 }
 
 // collection is a differ used for slices to show what items match and which don't
 type collection struct {
-	found   []interface{}
-	missing []interface{}
+	found   []any
+	missing []any
 }
 
 func (c *collection) String() (s string) {
@@ -392,19 +446,19 @@ func (c *collection) String() (s string) {
 }
 
 type diff struct {
-	x   interface{}
-	y   interface{}
+	x   any
+	y   any
 	msg string
 }
 
-func newDiff(x, y interface{}) *diff {
+func newDiff(x, y any) *diff {
 	return &diff{
 		x:   x,
 		y:   y,
 		msg: fmt.Sprintf(" + %v\n - %v", x, y)}
 }
 
-func newDiffMsg(x, y interface{}, s string) *diff {
+func newDiffMsg(x, y any, s string) *diff {
 	return &diff{x, y, s}
 }
 
@@ -414,7 +468,7 @@ func (d *diff) String() string {
 
 // mapDiff is a differ for maps
 type mapDiff struct {
-	values map[interface{}][]string
+	values map[any][]string
 }
 
 func (d *mapDiff) String() (s string) {

--- a/functions_test.go
+++ b/functions_test.go
@@ -105,8 +105,8 @@ func TestEqualFn(t *testing.T) {
 		},
 		"interface slice with private methods": {
 			Input: Args(
-				[]interface{}{test{Public: 1, private: "a"}, parent{}},
-				[]interface{}{test{Public: 1, private: "a"}, parent{}},
+				[]any{test{Public: 1, private: "a"}, parent{}},
+				[]any{test{Public: 1, private: "a"}, parent{}},
 			),
 			Expected: true,
 		},
@@ -118,6 +118,94 @@ func TestEqualFn(t *testing.T) {
 		},
 	}
 	New(fn, cases).Test(t)
+}
+
+func TestJSONEqual(t *testing.T) {
+	type response struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}
+	type input struct {
+		actual   any
+		expected any
+	}
+	fn := func(in input) (bool, error) {
+		eq, diff := JSONEqual(in.actual, in.expected)
+		if !eq {
+			return false, errors.New(diff)
+		}
+		return eq, nil
+	}
+	const embeddedFixture = `{
+		"name": "foo",
+		"count": 5
+	}`
+	cases := Cases[input, bool]{
+		"key order ignored": {
+			Input: input{
+				actual:   `{"b":2,"a":1}`,
+				expected: `{"a":1,"b":2}`,
+			},
+			Expected: true,
+		},
+		"whitespace ignored": {
+			Input: input{
+				actual:   `{"name":"foo","count":5}`,
+				expected: "{\n\t\"name\": \"foo\",\n\t\"count\": 5\n}",
+			},
+			Expected: true,
+		},
+		"struct vs json string": {
+			Input: input{
+				actual:   response{Name: "foo", Count: 5},
+				expected: `{"count":5,"name":"foo"}`,
+			},
+			Expected: true,
+		},
+		"embedded fixture string": {
+			Input: input{
+				actual:   response{Name: "foo", Count: 5},
+				expected: embeddedFixture,
+			},
+			Expected: true,
+		},
+		"semantic mismatch": {
+			Input: input{
+				actual:   response{Name: "foo", Count: 5},
+				expected: `{"name":"foo","count":9}`,
+			},
+			ShouldErr: true,
+		},
+		"invalid json actual": {
+			Input: input{
+				actual:   `{not json}`,
+				expected: `{}`,
+			},
+			ExpectedErr: errors.New("actual: invalid JSON: invalid character 'n'"),
+		},
+		"invalid json expected": {
+			Input: input{
+				actual:   `{}`,
+				expected: `{not json}`,
+			},
+			ExpectedErr: errors.New("expected: invalid JSON: invalid character 'n'"),
+		},
+		"number normalization": {
+			Input: input{
+				actual:   response{Name: "x", Count: 1},
+				expected: `{"name":"x","count":1}`,
+			},
+			Expected: true,
+		},
+		"nil both sides": {
+			Input: input{
+				actual:   nil,
+				expected: nil,
+			},
+			Expected: true,
+		},
+	}
+	New(fn, cases).SubTest(t)
 }
 
 func TestComparerOptions(t *testing.T) {
@@ -134,15 +222,15 @@ func TestComparerOptions(t *testing.T) {
 		Child   child
 		kid     child
 
-		Map   map[string]interface{}
+		Map   map[string]any
 		Slice []string
 	}
 	type Alias int
 
 	type input struct {
 		fn CompareFunc
-		v1 interface{}
-		v2 interface{}
+		v1 any
+		v2 any
 	}
 	fn := func(in input) (bool, error) {
 
@@ -233,7 +321,7 @@ func TestComparerOptions(t *testing.T) {
 		"Equate Empty": {
 			Input: input{
 				fn: EqualOpt(IgnoreAllUnexported, EquateEmpty),
-				v1: tStruct{Map: map[string]interface{}{}, Slice: []string{}},
+				v1: tStruct{Map: map[string]any{}, Slice: []string{}},
 				v2: tStruct{Map: nil, Slice: nil},
 			},
 			Expected: true,
@@ -388,12 +476,12 @@ func TestContainsFn(t *testing.T) {
 			Expected:  false,
 			ShouldErr: true,
 		},
-		"[]interface{}": {
-			Input:    Args([]interface{}{1, 2, 3, "abc", 4.5}, []interface{}{2, "abc"}),
+		"[]any": {
+			Input:    Args([]any{1, 2, 3, "abc", 4.5}, []any{2, "abc"}),
 			Expected: true,
 		},
-		"[]interface{} with int slice": {
-			Input:    Args([]interface{}{1, 2, 3, "abc", 4.5}, []int{2, 1}),
+		"[]any with int slice": {
+			Input:    Args([]any{1, 2, 3, "abc", 4.5}, []int{2, 1}),
 			Expected: true,
 		},
 		"expected is slice subset of actual": {
@@ -408,14 +496,14 @@ func TestContainsFn(t *testing.T) {
 			Input:    Args([]string{"abcdefghijklmnop", "qrstuvwxyz"}, []string{"abc", "def"}),
 			Expected: true,
 		},
-		"map[string]interface{}": {
+		"map[string]any": {
 			Input: Args(
-				map[string]interface{}{
+				map[string]any{
 					"int":     10,
 					"float64": 1.1,
 					"name":    "hello",
 				},
-				map[string]interface{}{"int": 10},
+				map[string]any{"int": 10},
 			),
 			Expected: true,
 		},

--- a/helper.go
+++ b/helper.go
@@ -6,7 +6,7 @@ import (
 
 // Args converts any number of parameters to an interface.
 // generally used with Case's Input for multiple params
-func Args(args ...interface{}) Input {
+func Args(args ...any) Input {
 	if len(args) == 1 {
 		return newInput(args[0])
 	}

--- a/input.go
+++ b/input.go
@@ -7,11 +7,11 @@ import (
 )
 
 // Input the input value given to the trial test function
-type Input struct { // TODO: try type Input interface{}
+type Input struct { // TODO: try making Input an interface type
 	value reflect.Value
 }
 
-func newInput(i interface{}) Input {
+func newInput(i any) Input {
 	return Input{value: reflect.ValueOf(i)}
 }
 
@@ -67,7 +67,7 @@ func (in Input) Uint() uint {
 }
 
 // Interface returns the current value of input
-func (in Input) Interface() interface{} {
+func (in Input) Interface() any {
 	//TODO: check for nil
 	if in.value.Kind() == reflect.Invalid {
 		return nil
@@ -102,7 +102,7 @@ func (in Input) Slice(i int) Input {
 }
 
 // Map returns the value for the provided key, panics on non map value
-func (in Input) Map(key interface{}) Input {
+func (in Input) Map(key any) Input {
 	// use reflection to access any map type map[string]string, etc
 	return Input{value: in.value.MapIndex(reflect.ValueOf(key))}
 }

--- a/trial.go
+++ b/trial.go
@@ -50,7 +50,7 @@ func colorGreen(s string) string {
 
 type (
 	// TestFunc a wrapper function used to setup the method being tested.
-	TestFunc func(in Input) (result interface{}, err error)
+	TestFunc func(in Input) (result any, err error)
 
 	// CompareFunc compares actual and expected to determine equality. It should return
 	// a human readable string representing the differences between actual and
@@ -58,14 +58,14 @@ type (
 	// Symbols with meaning:
 	// "-" elements missing from actual
 	// "+" elements missing from expected
-	CompareFunc               func(actual, expected interface{}) (equal bool, differences string)
+	CompareFunc               func(actual, expected any) (equal bool, differences string)
 	testFunc[In any, Out any] func(in In) (result Out, err error)
 )
 
 // Comparer interface is implemented by an object to check for equality
 // and show any differences found
 type Comparer interface {
-	Equals(interface{}) (bool, string)
+	Equals(any) (bool, string)
 }
 
 // Trial framework used to test different logical states
@@ -104,15 +104,15 @@ func New[In any, Out any](fn func(In) (Out, error), cases map[string]Case[In, Ou
 }
 
 // EqualFn override the default comparison method used.
-// see ContainsFn(x, y interface{}) (bool, string)
+// see ContainsFn(x, y any) (bool, string)
 // deprecated
 func (t *Trial[In, Out]) EqualFn(fn CompareFunc) *Trial[In, Out] {
 	return t.Comparer(fn)
 }
 
 // Comparer override the default comparison function.
-// see Contains(x, y interface{}) (bool, string)
-// see Equals(x, y interface{}) (bool, string)
+// see Contains(x, y any) (bool, string)
+// see Equals(x, y any) (bool, string)
 func (t *Trial[In, Out]) Comparer(fn CompareFunc) *Trial[In, Out] {
 	t.equalFn = fn
 	return t
@@ -264,17 +264,17 @@ func ErrType(err error) error {
 type result struct {
 	Success    bool
 	Message    string
-	value      interface{}
+	value      any
 	err        error
 	panicCheck bool
 }
 
-func (r *result) pass(format string, args ...interface{}) {
+func (r *result) pass(format string, args ...any) {
 	r.Success = true
 	r.Message = fmt.Sprintf(format, args...)
 }
 
-func (r *result) fail(format string, args ...interface{}) {
+func (r *result) fail(format string, args ...any) {
 	r.Success = false
 	r.Message = fmt.Sprintf(format, args...)
 }

--- a/trial_test.go
+++ b/trial_test.go
@@ -14,7 +14,7 @@ func TestMain(t *testing.M) {
 	localTest = false
 }
 func TestTrial_TestCase(t *testing.T) {
-	divideFn := func(in Input) (interface{}, error) {
+	divideFn := func(in Input) (any, error) {
 		return func(a, b int) (int, error) {
 			if b == 0 {
 				return 0, errors.New("divide by zero")
@@ -23,7 +23,7 @@ func TestTrial_TestCase(t *testing.T) {
 		}(in.Slice(0).Int(), in.Slice(1).Int())
 	}
 
-	panicFn := func(in Input) (interface{}, error) {
+	panicFn := func(in Input) (any, error) {
 		return func(s string) string {
 			t, err := time.Parse(time.RFC3339, s)
 			if err != nil {
@@ -93,7 +93,7 @@ func TestTrial_TestCase(t *testing.T) {
 			expResult: result{Success: false, Message: `PANIC: "parse time with unexpected panic" parsing time "invalid" as "2006-01-02T15:04:05Z07:00": cannot parse "invalid" as "2006"`},
 		},
 		"expected panic did not occur": {
-			trial: New(func(Input) (interface{}, error) {
+			trial: New(func(Input) (any, error) {
 				return nil, nil
 			}, nil),
 			Case: Case[Input, any]{
@@ -102,7 +102,7 @@ func TestTrial_TestCase(t *testing.T) {
 			expResult: result{Success: false, Message: `FAIL: "expected panic did not occur" did not panic`},
 		},
 		"test should error but no error occurred": {
-			trial: New(func(Input) (interface{}, error) {
+			trial: New(func(Input) (any, error) {
 				return nil, nil
 			}, nil),
 			Case: Case[Input, any]{
@@ -111,7 +111,7 @@ func TestTrial_TestCase(t *testing.T) {
 			expResult: result{Success: false, Message: `FAIL: "test should error but no error occurred" should error`},
 		},
 		"expected error string match": {
-			trial: New(func(Input) (interface{}, error) {
+			trial: New(func(Input) (any, error) {
 				return nil, errors.New("test error")
 			}, nil),
 			Case: Case[Input, any]{
@@ -128,7 +128,7 @@ func TestTrial_TestCase(t *testing.T) {
 			expResult: result{Success: false, Message: `FAIL: "expected error string does not match" error "divide by zero" does not match expected "test error"`},
 		},
 		"expected error of type testErr": {
-			trial: New(func(Input) (interface{}, error) {
+			trial: New(func(Input) (any, error) {
 				return nil, testErr{}
 			}, nil),
 			Case: Case[Input, any]{
@@ -137,7 +137,7 @@ func TestTrial_TestCase(t *testing.T) {
 			expResult: result{Success: true, Message: `PASS: "expected error of type testErr"`},
 		},
 		"error type testErr with nil response": {
-			trial: New(func(Input) (interface{}, error) {
+			trial: New(func(Input) (any, error) {
 				return nil, nil
 			}, nil),
 			Case: Case[Input, any]{
@@ -146,7 +146,7 @@ func TestTrial_TestCase(t *testing.T) {
 			expResult: result{Success: false, Message: `FAIL: "error type testErr with nil response"`},
 		},
 		"error type testErr with mismatch response": {
-			trial: New(func(Input) (interface{}, error) {
+			trial: New(func(Input) (any, error) {
 				return nil, errors.New("some error")
 			}, nil),
 			Case: Case[Input, any]{
@@ -155,7 +155,7 @@ func TestTrial_TestCase(t *testing.T) {
 			expResult: result{Success: false, Message: `FAIL: "error type testErr with mismatch response"`},
 		},
 		"timeout error": {
-			trial: New(func(Input) (interface{}, error) {
+			trial: New(func(Input) (any, error) {
 				time.Sleep(time.Second)
 				return nil, nil
 			}, nil).Timeout(time.Millisecond),
@@ -184,125 +184,125 @@ func (e testErr) Error() string {
 func TestInput(t *testing.T) {
 	type tester struct {
 		shouldPanic bool
-		fn          func() interface{}
-		expected    interface{}
+		fn          func() any
+		expected    any
 	}
 	cases := map[string]tester{
 		"string": {
-			fn:       func() interface{} { return newInput("hello world").String() },
+			fn:       func() any { return newInput("hello world").String() },
 			expected: "hello world",
 		},
 		"string (int)": {
-			fn:       func() interface{} { return newInput(123).String() },
+			fn:       func() any { return newInput(123).String() },
 			expected: "123",
 		},
 		"string (float)": {
-			fn:       func() interface{} { return newInput(12.8).String() },
+			fn:       func() any { return newInput(12.8).String() },
 			expected: "12.8",
 		},
 		"string (bool)": {
-			fn:       func() interface{} { return newInput(true).String() },
+			fn:       func() any { return newInput(true).String() },
 			expected: "true",
 		},
 		"string panic": {
-			fn:          func() interface{} { return newInput(struct{}{}).String() },
+			fn:          func() any { return newInput(struct{}{}).String() },
 			shouldPanic: true,
 		},
 		"bool": {
-			fn:       func() interface{} { return newInput(true).Bool() },
+			fn:       func() any { return newInput(true).Bool() },
 			expected: true,
 		},
 		"bool (string)": {
-			fn: func() interface{} {
+			fn: func() any {
 				newInput("false").Bool()
 				return newInput("true").Bool()
 			},
 			expected: true,
 		},
 		"bool (invalid)": {
-			fn:          func() interface{} { return newInput("abc").Bool() },
+			fn:          func() any { return newInput("abc").Bool() },
 			shouldPanic: true,
 		},
 		"int": {
-			fn:       func() interface{} { return newInput(12).Int() },
+			fn:       func() any { return newInput(12).Int() },
 			expected: 12,
 		},
 		"int (string)": {
-			fn:       func() interface{} { return newInput("12").Int() },
+			fn:       func() any { return newInput("12").Int() },
 			expected: 12,
 		},
 		"int (invalid)": {
-			fn:          func() interface{} { return newInput("abc").Int() },
+			fn:          func() any { return newInput("abc").Int() },
 			shouldPanic: true,
 		},
 		"uint": {
-			fn:       func() interface{} { return newInput(12).Uint() },
+			fn:       func() any { return newInput(12).Uint() },
 			expected: uint(12),
 		},
 		"uint (string)": {
-			fn:       func() interface{} { return newInput("12").Uint() },
+			fn:       func() any { return newInput("12").Uint() },
 			expected: uint(12),
 		},
 		"float64": {
-			fn:       func() interface{} { return newInput(12.4).Float64() },
+			fn:       func() any { return newInput(12.4).Float64() },
 			expected: 12.4,
 		},
 		"float64 (float32)": {
-			fn:       func() interface{} { return newInput(float32(12.4)).Float64() },
+			fn:       func() any { return newInput(float32(12.4)).Float64() },
 			expected: 12.399999618530273,
 		},
 		"float64 (int)": {
-			fn:       func() interface{} { return newInput(12).Float64() },
+			fn:       func() any { return newInput(12).Float64() },
 			expected: float64(12),
 		},
 		"float64 (string)": {
-			fn:       func() interface{} { return newInput("12.5").Float64() },
+			fn:       func() any { return newInput("12.5").Float64() },
 			expected: 12.5,
 		},
 		"map[string]string": {
-			fn:       func() interface{} { return newInput(map[string]string{"abc": "def"}).Map("abc").String() },
+			fn:       func() any { return newInput(map[string]string{"abc": "def"}).Map("abc").String() },
 			expected: "def",
 		},
 		"map[int]string": {
-			fn:       func() interface{} { return newInput(map[int]string{12: "def"}).Map(12).String() },
+			fn:       func() any { return newInput(map[int]string{12: "def"}).Map(12).String() },
 			expected: "def",
 		},
 		"map[interface]interface": {
-			fn:       func() interface{} { return newInput(map[interface{}]interface{}{12: "def"}).Map(12).String() },
+			fn:       func() any { return newInput(map[any]any{12: "def"}).Map(12).String() },
 			expected: "def",
 		},
 		"[]string": {
-			fn: func() interface{} {
+			fn: func() any {
 				in := newInput([]string{"ab", "cd", "ef", "g"})
 				return in.Slice(2).String()
 			},
 			expected: "ef",
 		},
 		"[]int": {
-			fn: func() interface{} {
-				in := newInput([]interface{}{1, 2, 3, 4})
+			fn: func() any {
+				in := newInput([]any{1, 2, 3, 4})
 				in.Slice(0).Int()
 				return in.Slice(2).Int()
 			},
 			expected: 3,
 		},
 		"slice out of bounds": {
-			fn:          func() interface{} { return newInput([]string{}).Slice(2).String() },
+			fn:          func() any { return newInput([]string{}).Slice(2).String() },
 			shouldPanic: true,
 		},
 		"invalid type": {
-			fn:          func() interface{} { return newInput([]string{"ab", "cd", "ef", "g"}).Map(2).String() },
+			fn:          func() any { return newInput([]string{"ab", "cd", "ef", "g"}).Map(2).String() },
 			shouldPanic: true,
 		},
 		"nil": {
-			fn:       func() interface{} { return newInput(nil).Interface() },
+			fn:       func() any { return newInput(nil).Interface() },
 			expected: nil,
 		},
 	}
 	for name, in := range cases {
 		// panic wrapper
 		t.Run(name, func(t *testing.T) {
-			var result interface{}
+			var result any
 			defer func() {
 				rec := recover()
 				if rec == nil && in.shouldPanic {
@@ -355,7 +355,7 @@ func TestColorDiagnostics(t *testing.T) {
 // in subTest display the line that SubTest is called rather than trial.go:96
 func TestSub(t *testing.T) {
 
-	fn := func(input Input) (interface{}, error) {
+	fn := func(input Input) (any, error) {
 		return 1, nil
 	}
 	cases := Cases{


### PR DESCRIPTION
### Quality check

- [x] Documentation included
- [x] Test coverage

### Summary

Adds `JSONEqual`, a comparer that normalizes both sides to JSON DOM shape before `cmp.Diff`, so tests ignore key ordering and whitespace when comparing struct output to embedded JSON fixtures or JSON strings.

Also replaces `interface{}` with `any` across public APIs, tests, and documentation for Go 1.18+ idioms. Documentation covers usage with `//go:embed` and comparer selection; `TestJSONEqual` covers key order, whitespace, struct-vs-JSON, invalid JSON, and number normalization.
