### PR TITLE
Add Error builder matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Go testing framework to make tests easier to create, maintain and debug.
     - check for expected panic cases with `ShouldPanic`
   - Test error cases 
     - Check that a function returns an error: `ShouldErr`
-    - Check that an error string contains expected string: `ExpectedErr`
-    - Check that an error is of expected type: `ExpectedErr: ErrType(err)`
+    - Check error message with `trial.Error()` (exact, `.Contains()`, or `.Regex()`)
+    - Legacy substring match: `ExpectedErr: errors.New("fragment")`
+    - Check error type: `ExpectedErr: trial.ErrType(err)` (optionally with `.Contains()` or `.Regex()`)
   - Fail tests that take too long to complete
     - `trial.New(fn,cases).Timeout(time.Second)`
   - Run subtests in parallel for faster execution
@@ -88,10 +89,11 @@ Each case field is described below:
 - **Expected** *generic* - the expected output of the method being tested.
   - This is compared with the result from the TestFunc
 - **ShouldErr** *bool* - indicates the function should return an error
-- **ExpectedErr** *error* - verifies the function error string matches the result
-  - uses strings.Contains to check
+- **ExpectedErr** *error* - verifies the function returns an expected error
+  - `trial.Error("msg")` — exact message match; `.Contains()` for substring; `.Regex()` for pattern
+  - `trial.ErrType(err)` — type match; `.Contains()` / `.Regex()` add message checks
+  - `errors.New("fragment")` — legacy substring match via `strings.Contains`
   - also implies that the method should error so setting ShouldErr to true is not required
-  - use *ErrType* to test that the error is the same type as expected. 
 - **ShouldPanic** *bool* - indicates the method should panic
 
 ### Trial Setup

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Go testing framework to make tests easier to create, maintain and debug.
     - each test is self isolated so a panic won't stop other cases from running 
     - check for expected panic cases with `ShouldPanic`
   - Test error cases 
-    - Check that a function returns an error: `ShouldErr`
-    - Check error message with `trial.Error()` (exact, `.Contains()`, or `.Regex()`)
+    - Check that a function returns an error: `ShouldErr` or `ExpectedErr: trial.Error()`
+    - Match error message: `trial.Error().Exact()`, `.Contains()`, or `.Regex()`
     - Legacy substring match: `ExpectedErr: errors.New("fragment")`
-    - Check error type: `ExpectedErr: trial.ErrType(err)` (optionally with `.Contains()` or `.Regex()`)
+    - Check error type: `ExpectedErr: trial.Error().IsType(err)`
   - Fail tests that take too long to complete
     - `trial.New(fn,cases).Timeout(time.Second)`
   - Run subtests in parallel for faster execution
@@ -90,8 +90,9 @@ Each case field is described below:
   - This is compared with the result from the TestFunc
 - **ShouldErr** *bool* - indicates the function should return an error
 - **ExpectedErr** *error* - verifies the function returns an expected error
-  - `trial.Error("msg")` — exact message match; `.Contains()` for substring; `.Regex()` for pattern
-  - `trial.ErrType(err)` — type match; `.Contains()` / `.Regex()` add message checks
+  - `trial.Error()` — any error
+  - `trial.Error().Exact("msg")` — exact message; `.Contains("msg")` for substring; `.Regex(pat)` for pattern
+  - `trial.Error().IsType(err)` — type match; chain `.Contains()` / `.Regex()` for message checks
   - `errors.New("fragment")` — legacy substring match via `strings.Contains`
   - also implies that the method should error so setting ShouldErr to true is not required
 - **ShouldPanic** *bool* - indicates the method should panic

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,7 +16,7 @@ type Case[In any, Out any] struct {
     Input       In
     Expected    Out
     ShouldErr   bool   // expect any error
-    ExpectedErr error  // expect error (see Error, ErrType, or errors.New)
+    ExpectedErr error  // expect error (see Error() builder, or errors.New)
     ShouldPanic bool   // expect panic
 }
 
@@ -32,8 +32,8 @@ type CompareFunc func(actual, expected interface{}) (equal bool, differences str
 | Function | Description |
 |----------|-------------|
 | `New(fn, cases)` | Create Trial instance |
-| `Error(text)` | Expected error matcher (exact by default; use `.Contains()` or `.Regex()`) |
-| `ErrType(err)` | Expected error type matcher (use `.Contains()` or `.Regex()` for message) |
+| `Error()` | Expected error matcher builder (`.Exact`, `.Contains`, `.Regex`, `.IsType`) |
+| `ErrType(err)` | Deprecated — use `Error().IsType(err)` |
 
 ## Trial Methods
 
@@ -57,8 +57,8 @@ type CompareFunc func(actual, expected interface{}) (equal bool, differences str
 
 **Notes:**
 - `ExpectedErr` implies `ShouldErr`, no need to set both
-- `trial.Error(text)` — exact message match; `.Contains()` for substring; `.Regex()` for pattern
-- `trial.ErrType(MyError{})` — type match; `.Contains()` / `.Regex()` add message checks
+- `trial.Error()` — any error; `.Exact(msg)` for full message; `.Contains(msg)` for substring; `.Regex(pat)` for pattern
+- `trial.Error().IsType(err)` — type match; chain `.Contains()` / `.Regex()` for message checks
 - `errors.New("fragment")` — legacy substring match via `strings.Contains`
 
 ## Input Methods

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,7 +16,7 @@ type Case[In any, Out any] struct {
     Input       In
     Expected    Out
     ShouldErr   bool   // expect any error
-    ExpectedErr error  // expect error containing this string (or use ErrType for type check)
+    ExpectedErr error  // expect error (see Error, ErrType, or errors.New)
     ShouldPanic bool   // expect panic
 }
 
@@ -32,7 +32,8 @@ type CompareFunc func(actual, expected interface{}) (equal bool, differences str
 | Function | Description |
 |----------|-------------|
 | `New(fn, cases)` | Create Trial instance |
-| `ErrType(err)` | Wrap error for type-based comparison |
+| `Error(text)` | Expected error matcher (exact by default; use `.Contains()` or `.Regex()`) |
+| `ErrType(err)` | Expected error type matcher (use `.Contains()` or `.Regex()` for message) |
 
 ## Trial Methods
 
@@ -51,12 +52,14 @@ type CompareFunc func(actual, expected interface{}) (equal bool, differences str
 | `Input` | `In` | Value passed to test function |
 | `Expected` | `Out` | Expected return value |
 | `ShouldErr` | `bool` | Expect any error |
-| `ExpectedErr` | `error` | Expect error containing string (uses `strings.Contains`) |
+| `ExpectedErr` | `error` | Expect specific error (see matching modes below) |
 | `ShouldPanic` | `bool` | Expect panic |
 
 **Notes:**
 - `ExpectedErr` implies `ShouldErr`, no need to set both
-- Use `ErrType(MyError{})` with `ExpectedErr` to check error types
+- `trial.Error(text)` — exact message match; `.Contains()` for substring; `.Regex()` for pattern
+- `trial.ErrType(MyError{})` — type match; `.Contains()` / `.Regex()` add message checks
+- `errors.New("fragment")` — legacy substring match via `strings.Contains`
 
 ## Input Methods
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -131,28 +131,32 @@ cases := trial.Cases[string, output]{
 }
 ```
 
-### Error - Flexible Error Message Matching
+### Error - Flexible Error Matching
 
-Use `trial.Error()` for exact, substring, or regex matching:
+Use `trial.Error()` with builder methods:
 
 ```go
 cases := trial.Cases[string, int]{
+    "any error": {
+        Input:       "bad",
+        ExpectedErr: trial.Error(),
+    },
     "exact message": {
         Input:       "bad",
-        ExpectedErr: trial.Error("invalid input"),
+        ExpectedErr: trial.Error().Exact("invalid input"),
     },
     "substring match": {
         Input:       "slow",
-        ExpectedErr: trial.Error("timeout").Contains(),
+        ExpectedErr: trial.Error().Contains("timeout"),
     },
     "regex match": {
         Input:       "bad",
-        ExpectedErr: trial.Error(`invalid.*format`).Regex(),
+        ExpectedErr: trial.Error().Regex(`invalid.*format`),
     },
 }
 ```
 
-### ErrType - Expect Specific Error Type
+### IsType - Expect Specific Error Type
 
 ```go
 type ValidationError struct {
@@ -166,15 +170,15 @@ func (e ValidationError) Error() string {
 cases := trial.Cases[string, string]{
     "validation error": {
         Input:       "",
-        ExpectedErr: trial.ErrType(ValidationError{}),
+        ExpectedErr: trial.Error().IsType(ValidationError{}),
     },
     "validation with message": {
         Input:       "",
-        ExpectedErr: trial.ErrType(ValidationError{}).Contains("field required"),
+        ExpectedErr: trial.Error().IsType(ValidationError{}).Contains("field required"),
     },
     "validation with regex": {
         Input:       "",
-        ExpectedErr: trial.ErrType(ValidationError{}).Regex(`field .+ required`),
+        ExpectedErr: trial.Error().IsType(ValidationError{}).Regex(`field .+ required`),
     },
 }
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -120,13 +120,34 @@ cases := trial.Cases[[]int, int]{
 
 ### ExpectedErr - Expect Specific Error Message
 
-Uses `strings.Contains` to check the error message:
+Uses `strings.Contains` to check the error message (legacy):
 
 ```go
 cases := trial.Cases[string, output]{
     "invalid character": {
         Input:       `{"Value", "abc"}`,
         ExpectedErr: errors.New("invalid character"),
+    },
+}
+```
+
+### Error - Flexible Error Message Matching
+
+Use `trial.Error()` for exact, substring, or regex matching:
+
+```go
+cases := trial.Cases[string, int]{
+    "exact message": {
+        Input:       "bad",
+        ExpectedErr: trial.Error("invalid input"),
+    },
+    "substring match": {
+        Input:       "slow",
+        ExpectedErr: trial.Error("timeout").Contains(),
+    },
+    "regex match": {
+        Input:       "bad",
+        ExpectedErr: trial.Error(`invalid.*format`).Regex(),
     },
 }
 ```
@@ -146,6 +167,14 @@ cases := trial.Cases[string, string]{
     "validation error": {
         Input:       "",
         ExpectedErr: trial.ErrType(ValidationError{}),
+    },
+    "validation with message": {
+        Input:       "",
+        ExpectedErr: trial.ErrType(ValidationError{}).Contains("field required"),
+    },
+    "validation with regex": {
+        Input:       "",
+        ExpectedErr: trial.ErrType(ValidationError{}).Regex(`field .+ required`),
     },
 }
 ```

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -123,12 +123,29 @@ Use `Hour()` instead of `TimeHour()`, use `Day()` instead of `TimeDay()`.
 
 ## Error Helpers
 
-### ErrType
+### Error
 
-Wraps an error for **type-based comparison**. When used with `ExpectedErr`, trial checks that the returned error is the same type (not message).
+Creates an expected error matcher. By default, compares the **full** error message exactly. Use `.Contains()` for substring matching or `.Regex()` for pattern matching.
 
 ```go
-func ErrType(err error) error
+func Error(text string) /* error matcher */
+```
+
+**Examples:**
+```go
+ExpectedErr: trial.Error("invalid input")                    // exact match
+ExpectedErr: trial.Error("timeout").Contains()              // substring
+ExpectedErr: trial.Error(`invalid.*format`).Regex()         // regex
+```
+
+Invalid regex patterns fail at compare time with a clear failure message (not at case initialization).
+
+### ErrType
+
+Wraps an error for **type-based comparison**. When used with `ExpectedErr`, trial checks that the returned error is the same type (not message). Use `.Contains()` or `.Regex()` to also match the message.
+
+```go
+func ErrType(err error) /* error matcher */
 ```
 
 **Example:**
@@ -141,8 +158,14 @@ cases := trial.Cases[string, string]{
         Input:       "",
         ExpectedErr: trial.ErrType(ValidationError{}),
     },
+    "validation with message": {
+        Input:       "",
+        ExpectedErr: trial.ErrType(ValidationError{}).Contains("field required"),
+    },
 }
 ```
+
+**Legacy:** `errors.New("fragment")` with `ExpectedErr` still uses substring matching via `strings.Contains`.
 
 ---
 

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -125,45 +125,26 @@ Use `Hour()` instead of `TimeHour()`, use `Day()` instead of `TimeDay()`.
 
 ### Error
 
-Creates an expected error matcher. By default, compares the **full** error message exactly. Use `.Contains()` for substring matching or `.Regex()` for pattern matching.
+Creates an expected error matcher. With no methods, any error matches. Chain builder methods to constrain the match.
 
 ```go
-func Error(text string) /* error matcher */
+func Error() /* error matcher */
 ```
 
 **Examples:**
 ```go
-ExpectedErr: trial.Error("invalid input")                    // exact match
-ExpectedErr: trial.Error("timeout").Contains()              // substring
-ExpectedErr: trial.Error(`invalid.*format`).Regex()         // regex
+ExpectedErr: trial.Error()                              // any error
+ExpectedErr: trial.Error().Exact("invalid input")     // exact match
+ExpectedErr: trial.Error().Contains("timeout")        // substring
+ExpectedErr: trial.Error().Regex(`invalid.*format`) // regex
+ExpectedErr: trial.Error().IsType(ValidationError{})  // type match
 ```
 
-Invalid regex patterns fail at compare time with a clear failure message (not at case initialization).
+Invalid regex patterns fail at compare time with a clear failure message.
 
 ### ErrType
 
-Wraps an error for **type-based comparison**. When used with `ExpectedErr`, trial checks that the returned error is the same type (not message). Use `.Contains()` or `.Regex()` to also match the message.
-
-```go
-func ErrType(err error) /* error matcher */
-```
-
-**Example:**
-```go
-type ValidationError struct{ Field string }
-func (e ValidationError) Error() string { return "invalid " + e.Field }
-
-cases := trial.Cases[string, string]{
-    "returns validation error": {
-        Input:       "",
-        ExpectedErr: trial.ErrType(ValidationError{}),
-    },
-    "validation with message": {
-        Input:       "",
-        ExpectedErr: trial.ErrType(ValidationError{}).Contains("field required"),
-    },
-}
-```
+Deprecated. Use `Error().IsType(err)` instead.
 
 **Legacy:** `errors.New("fragment")` with `ExpectedErr` still uses substring matching via `strings.Contains`.
 

--- a/error.go
+++ b/error.go
@@ -1,0 +1,140 @@
+package trial
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+)
+
+type matchMode int
+
+const (
+	matchExact matchMode = iota
+	matchContains
+	matchRegex
+)
+
+type expectErr struct {
+	err  error
+	text string
+	mode matchMode
+}
+
+// Error returns an expected error matcher that compares the full error message
+// by default. Use Contains or Regex to change the comparison mode.
+func Error(text string) expectErr {
+	return expectErr{text: text, mode: matchExact}
+}
+
+// ErrType can be used with ExpectedErr to check that the expected err is of a
+// certain type. Use Contains or Regex to also match the error message.
+func ErrType(err error) expectErr {
+	return expectErr{err: err}
+}
+
+// Contains sets substring matching on the error message. When called on
+// Error(text), the text argument is reused. When called on ErrType, a substring
+// argument is required.
+func (e expectErr) Contains(substr ...string) error {
+	if len(substr) > 0 {
+		e.text = substr[0]
+	}
+	e.mode = matchContains
+	return e
+}
+
+// Regex sets regex matching on the error message. When called on Error(text),
+// the text argument is reused as the pattern. When called on ErrType, a pattern
+// argument is required. Invalid patterns fail at compare time with a clear
+// error message.
+func (e expectErr) Regex(pattern ...string) error {
+	if len(pattern) > 0 {
+		e.text = pattern[0]
+	}
+	e.mode = matchRegex
+	return e
+}
+
+func (e expectErr) modeWord() string {
+	switch e.mode {
+	case matchContains:
+		return "containing"
+	case matchRegex:
+		return "matching pattern"
+	default:
+		return "exactly"
+	}
+}
+
+func (e expectErr) Error() string {
+	if e.text == "" {
+		if e.err == nil {
+			return ""
+		}
+		if msg := e.err.Error(); msg != "" {
+			return msg
+		}
+		return fmt.Sprintf("error of type %T", e.err)
+	}
+	desc := fmt.Sprintf("%s %q", e.modeWord(), e.text)
+	if e.err != nil {
+		return fmt.Sprintf("error of type %T %s", e.err, desc)
+	}
+	return "error " + desc
+}
+
+func (e expectErr) matches(actual error) (matched bool, failMsg string) {
+	if e.err != nil {
+		if reflect.TypeOf(actual) != reflect.TypeOf(e.err) {
+			if e.text == "" {
+				return false, fmt.Sprintf("error %q is not %T", actual, e.err)
+			}
+			switch e.mode {
+			case matchContains:
+				return false, fmt.Sprintf("error %q is not %T (expected to contain %q)", actual, e.err, e.text)
+			case matchRegex:
+				return false, fmt.Sprintf("error %q is not %T (expected to match pattern %q)", actual, e.err, e.text)
+			default:
+				return false, fmt.Sprintf("error %q is not %T (expected exactly %q)", actual, e.err, e.text)
+			}
+		}
+	}
+
+	if e.text == "" {
+		return true, ""
+	}
+
+	actualMsg := actual.Error()
+	switch e.mode {
+	case matchContains:
+		if strings.Contains(actualMsg, e.text) {
+			return true, ""
+		}
+		return false, fmt.Sprintf("error %q does not contain %q", actual, e.text)
+	case matchRegex:
+		re, err := regexp.Compile(e.text)
+		if err != nil {
+			return false, fmt.Sprintf("invalid regex pattern %q: %v", e.text, err)
+		}
+		if re.MatchString(actualMsg) {
+			return true, ""
+		}
+		return false, fmt.Sprintf("error %q does not match pattern %q", actual, e.text)
+	default:
+		if actualMsg == e.text {
+			return true, ""
+		}
+		return false, fmt.Sprintf("error %q does not match exactly %q", actual, e.text)
+	}
+}
+
+func isExpectedError(actual, expected error) (matched bool, failMsg string) {
+	if e, ok := expected.(expectErr); ok {
+		return e.matches(actual)
+	}
+	if strings.Contains(actual.Error(), expected.Error()) {
+		return true, ""
+	}
+	return false, ""
+}

--- a/error.go
+++ b/error.go
@@ -21,39 +21,43 @@ type expectErr struct {
 	mode matchMode
 }
 
-// Error returns an expected error matcher that compares the full error message
-// by default. Use Contains or Regex to change the comparison mode.
-func Error(text string) expectErr {
-	return expectErr{text: text, mode: matchExact}
+// Error returns an expected error matcher. Use builder methods to constrain the
+// match: IsType, Exact, Contains, or Regex. With no methods, any error matches.
+func Error() expectErr {
+	return expectErr{}
 }
 
-// ErrType can be used with ExpectedErr to check that the expected err is of a
-// certain type. Use Contains or Regex to also match the error message.
-func ErrType(err error) expectErr {
-	return expectErr{err: err}
+// IsType requires the actual error to be the same type as err.
+func (e expectErr) IsType(err error) expectErr {
+	e.err = err
+	return e
 }
 
-// Contains sets substring matching on the error message. When called on
-// Error(text), the text argument is reused. When called on ErrType, a substring
-// argument is required.
-func (e expectErr) Contains(substr ...string) error {
-	if len(substr) > 0 {
-		e.text = substr[0]
-	}
+// Exact requires the error message to match exactly.
+func (e expectErr) Exact(msg string) error {
+	e.text = msg
+	e.mode = matchExact
+	return e
+}
+
+// Contains requires the error message to contain substr.
+func (e expectErr) Contains(substr string) error {
+	e.text = substr
 	e.mode = matchContains
 	return e
 }
 
-// Regex sets regex matching on the error message. When called on Error(text),
-// the text argument is reused as the pattern. When called on ErrType, a pattern
-// argument is required. Invalid patterns fail at compare time with a clear
-// error message.
-func (e expectErr) Regex(pattern ...string) error {
-	if len(pattern) > 0 {
-		e.text = pattern[0]
-	}
+// Regex requires the error message to match pattern. Invalid patterns fail at
+// compare time with a clear error message.
+func (e expectErr) Regex(pattern string) error {
+	e.text = pattern
 	e.mode = matchRegex
 	return e
+}
+
+// ErrType is deprecated. Use Error().IsType(err) instead.
+func ErrType(err error) error {
+	return Error().IsType(err)
 }
 
 func (e expectErr) modeWord() string {
@@ -70,7 +74,7 @@ func (e expectErr) modeWord() string {
 func (e expectErr) Error() string {
 	if e.text == "" {
 		if e.err == nil {
-			return ""
+			return "any error"
 		}
 		if msg := e.err.Error(); msg != "" {
 			return msg

--- a/error_test.go
+++ b/error_test.go
@@ -19,45 +19,59 @@ func TestError_matching(t *testing.T) {
 		wantPass  bool
 		wantInMsg string
 	}{
+		"any error pass": {
+			fn:        errFn("anything"),
+			expected:  Error(),
+			wantPass:  true,
+			wantInMsg: `PASS: "any error pass"`,
+		},
+		"any error fail when no error": {
+			fn: func(Input) (any, error) {
+				return nil, nil
+			},
+			expected:  Error(),
+			wantPass:  false,
+			wantInMsg: `should error`,
+		},
 		"exact pass": {
 			fn:        errFn("test error"),
-			expected:  Error("test error"),
+			expected:  Error().Exact("test error"),
 			wantPass:  true,
 			wantInMsg: `PASS: "exact pass"`,
 		},
 		"exact fail extra text": {
 			fn:        errFn("test error: details"),
-			expected:  Error("test error"),
+			expected:  Error().Exact("test error"),
 			wantPass:  false,
 			wantInMsg: `does not match exactly`,
 		},
-		"contains pass from Error": {
+		"contains pass": {
 			fn:        errFn("request timeout after 5s"),
-			expected:  Error("timeout").Contains(),
+			expected:  Error().Contains("timeout"),
 			wantPass:  true,
-			wantInMsg: `PASS: "contains pass from Error"`,
+			wantInMsg: `PASS: "contains pass"`,
 		},
 		"contains fail": {
 			fn:        errFn("not found"),
-			expected:  Error("timeout").Contains(),
+			expected:  Error().Contains("timeout"),
 			wantPass:  false,
 			wantInMsg: `does not contain`,
 		},
-		"regex pass from Error": {
+		"regex pass": {
 			fn:        errFn("invalid xyz format"),
-			expected:  Error(`invalid.*format`).Regex(),
+			expected:  Error().Regex(`invalid.*format`),
 			wantPass:  true,
-			wantInMsg: `PASS: "regex pass from Error"`,
+			wantInMsg: `PASS: "regex pass"`,
 		},
 		"regex fail": {
 			fn:        errFn("bad format"),
-			expected:  Error(`invalid.*format`).Regex(),
+			expected:  Error().Regex(`invalid.*format`),
 			wantPass:  false,
 			wantInMsg: `does not match pattern`,
 		},
 		"invalid regex pattern": {
 			fn:        errFn("any error"),
-			expected:  Error(`[invalid`).Regex(),
+			expected:  Error().Regex(`[invalid`),
 			wantPass:  false,
 			wantInMsg: `invalid regex pattern`,
 		},
@@ -87,7 +101,7 @@ type typedErr struct{ msg string }
 
 func (e typedErr) Error() string { return e.msg }
 
-func TestErrType_matching(t *testing.T) {
+func TestError_IsType_matching(t *testing.T) {
 	cases := map[string]struct {
 		fn        func(Input) (any, error)
 		expected  error
@@ -98,7 +112,7 @@ func TestErrType_matching(t *testing.T) {
 			fn: func(Input) (any, error) {
 				return nil, typedErr{msg: "anything"}
 			},
-			expected:  ErrType(typedErr{}),
+			expected:  Error().IsType(typedErr{}),
 			wantPass:  true,
 			wantInMsg: `PASS: "type only pass"`,
 		},
@@ -106,7 +120,7 @@ func TestErrType_matching(t *testing.T) {
 			fn: func(Input) (any, error) {
 				return nil, errors.New("plain")
 			},
-			expected:  ErrType(typedErr{}),
+			expected:  Error().IsType(typedErr{}),
 			wantPass:  false,
 			wantInMsg: `is not trial.typedErr`,
 		},
@@ -114,7 +128,7 @@ func TestErrType_matching(t *testing.T) {
 			fn: func(Input) (any, error) {
 				return nil, typedErr{msg: "validation failed: field required"}
 			},
-			expected:  ErrType(typedErr{}).Contains("field required"),
+			expected:  Error().IsType(typedErr{}).Contains("field required"),
 			wantPass:  true,
 			wantInMsg: `PASS: "type and contains pass"`,
 		},
@@ -122,7 +136,7 @@ func TestErrType_matching(t *testing.T) {
 			fn: func(Input) (any, error) {
 				return nil, typedErr{msg: "validation failed"}
 			},
-			expected:  ErrType(typedErr{}).Contains("field required"),
+			expected:  Error().IsType(typedErr{}).Contains("field required"),
 			wantPass:  false,
 			wantInMsg: `does not contain`,
 		},
@@ -130,7 +144,7 @@ func TestErrType_matching(t *testing.T) {
 			fn: func(Input) (any, error) {
 				return nil, errors.New("field required")
 			},
-			expected:  ErrType(typedErr{}).Contains("field required"),
+			expected:  Error().IsType(typedErr{}).Contains("field required"),
 			wantPass:  false,
 			wantInMsg: `is not trial.typedErr`,
 		},
@@ -138,7 +152,7 @@ func TestErrType_matching(t *testing.T) {
 			fn: func(Input) (any, error) {
 				return nil, typedErr{msg: "field abc required"}
 			},
-			expected:  ErrType(typedErr{}).Regex(`field .+ required`),
+			expected:  Error().IsType(typedErr{}).Regex(`field .+ required`),
 			wantPass:  true,
 			wantInMsg: `PASS: "type and regex pass"`,
 		},
@@ -146,7 +160,7 @@ func TestErrType_matching(t *testing.T) {
 			fn: func(Input) (any, error) {
 				return nil, typedErr{msg: "field missing"}
 			},
-			expected:  ErrType(typedErr{}).Regex(`field .+ required`),
+			expected:  Error().IsType(typedErr{}).Regex(`field .+ required`),
 			wantPass:  false,
 			wantInMsg: `does not match pattern`,
 		},
@@ -154,9 +168,17 @@ func TestErrType_matching(t *testing.T) {
 			fn: func(Input) (any, error) {
 				return nil, typedErr{msg: "field required"}
 			},
-			expected:  ErrType(typedErr{}).Regex(`[invalid`),
+			expected:  Error().IsType(typedErr{}).Regex(`[invalid`),
 			wantPass:  false,
 			wantInMsg: `invalid regex pattern`,
+		},
+		"deprecated ErrType still works": {
+			fn: func(Input) (any, error) {
+				return nil, typedErr{msg: "anything"}
+			},
+			expected:  ErrType(typedErr{}),
+			wantPass:  true,
+			wantInMsg: `PASS: "deprecated ErrType still works"`,
 		},
 	}
 
@@ -181,33 +203,38 @@ func TestExpectErr_Error_string(t *testing.T) {
 		want string
 	}{
 		{
+			name: "any error",
+			err:  Error(),
+			want: "any error",
+		},
+		{
 			name: "exact",
-			err:  Error("timeout"),
+			err:  Error().Exact("timeout"),
 			want: `error exactly "timeout"`,
 		},
 		{
 			name: "contains",
-			err:  Error("timeout").Contains(),
+			err:  Error().Contains("timeout"),
 			want: `error containing "timeout"`,
 		},
 		{
 			name: "regex",
-			err:  Error(`time.*out`).Regex(),
+			err:  Error().Regex(`time.*out`),
 			want: `error matching pattern "time.*out"`,
 		},
 		{
-			name: "type only",
-			err:  ErrType(typedErr{}),
+			name: "is type only",
+			err:  Error().IsType(typedErr{}),
 			want: "error of type trial.typedErr",
 		},
 		{
-			name: "type with error message",
-			err:  ErrType(errors.New("not found")),
+			name: "is type with error message",
+			err:  Error().IsType(errors.New("not found")),
 			want: "not found",
 		},
 		{
-			name: "type contains",
-			err:  ErrType(typedErr{}).Contains("required"),
+			name: "is type contains",
+			err:  Error().IsType(typedErr{}).Contains("required"),
 			want: `error of type trial.typedErr containing "required"`,
 		},
 	}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,222 @@
+package trial
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestError_matching(t *testing.T) {
+	errFn := func(msg string) func(Input) (any, error) {
+		return func(Input) (any, error) {
+			return nil, errors.New(msg)
+		}
+	}
+
+	cases := map[string]struct {
+		fn        func(Input) (any, error)
+		expected  error
+		wantPass  bool
+		wantInMsg string
+	}{
+		"exact pass": {
+			fn:        errFn("test error"),
+			expected:  Error("test error"),
+			wantPass:  true,
+			wantInMsg: `PASS: "exact pass"`,
+		},
+		"exact fail extra text": {
+			fn:        errFn("test error: details"),
+			expected:  Error("test error"),
+			wantPass:  false,
+			wantInMsg: `does not match exactly`,
+		},
+		"contains pass from Error": {
+			fn:        errFn("request timeout after 5s"),
+			expected:  Error("timeout").Contains(),
+			wantPass:  true,
+			wantInMsg: `PASS: "contains pass from Error"`,
+		},
+		"contains fail": {
+			fn:        errFn("not found"),
+			expected:  Error("timeout").Contains(),
+			wantPass:  false,
+			wantInMsg: `does not contain`,
+		},
+		"regex pass from Error": {
+			fn:        errFn("invalid xyz format"),
+			expected:  Error(`invalid.*format`).Regex(),
+			wantPass:  true,
+			wantInMsg: `PASS: "regex pass from Error"`,
+		},
+		"regex fail": {
+			fn:        errFn("bad format"),
+			expected:  Error(`invalid.*format`).Regex(),
+			wantPass:  false,
+			wantInMsg: `does not match pattern`,
+		},
+		"invalid regex pattern": {
+			fn:        errFn("any error"),
+			expected:  Error(`[invalid`).Regex(),
+			wantPass:  false,
+			wantInMsg: `invalid regex pattern`,
+		},
+		"legacy errors.New substring": {
+			fn:        errFn("test error"),
+			expected:  errors.New("test error"),
+			wantPass:  true,
+			wantInMsg: `PASS: "legacy errors.New substring"`,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tr := New(tc.fn, nil)
+			r := tr.testCase(name, Case[Input, any]{ExpectedErr: tc.expected})
+			if r.Success != tc.wantPass {
+				t.Fatalf("Success = %v, want %v; message: %s", r.Success, tc.wantPass, r.Message)
+			}
+			if !strings.Contains(r.Message, tc.wantInMsg) {
+				t.Fatalf("message %q does not contain %q", r.Message, tc.wantInMsg)
+			}
+		})
+	}
+}
+
+type typedErr struct{ msg string }
+
+func (e typedErr) Error() string { return e.msg }
+
+func TestErrType_matching(t *testing.T) {
+	cases := map[string]struct {
+		fn        func(Input) (any, error)
+		expected  error
+		wantPass  bool
+		wantInMsg string
+	}{
+		"type only pass": {
+			fn: func(Input) (any, error) {
+				return nil, typedErr{msg: "anything"}
+			},
+			expected:  ErrType(typedErr{}),
+			wantPass:  true,
+			wantInMsg: `PASS: "type only pass"`,
+		},
+		"type only fail wrong type": {
+			fn: func(Input) (any, error) {
+				return nil, errors.New("plain")
+			},
+			expected:  ErrType(typedErr{}),
+			wantPass:  false,
+			wantInMsg: `is not trial.typedErr`,
+		},
+		"type and contains pass": {
+			fn: func(Input) (any, error) {
+				return nil, typedErr{msg: "validation failed: field required"}
+			},
+			expected:  ErrType(typedErr{}).Contains("field required"),
+			wantPass:  true,
+			wantInMsg: `PASS: "type and contains pass"`,
+		},
+		"type and contains fail wrong message": {
+			fn: func(Input) (any, error) {
+				return nil, typedErr{msg: "validation failed"}
+			},
+			expected:  ErrType(typedErr{}).Contains("field required"),
+			wantPass:  false,
+			wantInMsg: `does not contain`,
+		},
+		"type and contains fail wrong type": {
+			fn: func(Input) (any, error) {
+				return nil, errors.New("field required")
+			},
+			expected:  ErrType(typedErr{}).Contains("field required"),
+			wantPass:  false,
+			wantInMsg: `is not trial.typedErr`,
+		},
+		"type and regex pass": {
+			fn: func(Input) (any, error) {
+				return nil, typedErr{msg: "field abc required"}
+			},
+			expected:  ErrType(typedErr{}).Regex(`field .+ required`),
+			wantPass:  true,
+			wantInMsg: `PASS: "type and regex pass"`,
+		},
+		"type and regex fail": {
+			fn: func(Input) (any, error) {
+				return nil, typedErr{msg: "field missing"}
+			},
+			expected:  ErrType(typedErr{}).Regex(`field .+ required`),
+			wantPass:  false,
+			wantInMsg: `does not match pattern`,
+		},
+		"type and invalid regex": {
+			fn: func(Input) (any, error) {
+				return nil, typedErr{msg: "field required"}
+			},
+			expected:  ErrType(typedErr{}).Regex(`[invalid`),
+			wantPass:  false,
+			wantInMsg: `invalid regex pattern`,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tr := New(tc.fn, nil)
+			r := tr.testCase(name, Case[Input, any]{ExpectedErr: tc.expected})
+			if r.Success != tc.wantPass {
+				t.Fatalf("Success = %v, want %v; message: %s", r.Success, tc.wantPass, r.Message)
+			}
+			if !strings.Contains(r.Message, tc.wantInMsg) {
+				t.Fatalf("message %q does not contain %q", r.Message, tc.wantInMsg)
+			}
+		})
+	}
+}
+
+func TestExpectErr_Error_string(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "exact",
+			err:  Error("timeout"),
+			want: `error exactly "timeout"`,
+		},
+		{
+			name: "contains",
+			err:  Error("timeout").Contains(),
+			want: `error containing "timeout"`,
+		},
+		{
+			name: "regex",
+			err:  Error(`time.*out`).Regex(),
+			want: `error matching pattern "time.*out"`,
+		},
+		{
+			name: "type only",
+			err:  ErrType(typedErr{}),
+			want: "error of type trial.typedErr",
+		},
+		{
+			name: "type with error message",
+			err:  ErrType(errors.New("not found")),
+			want: "not found",
+		},
+		{
+			name: "type contains",
+			err:  ErrType(typedErr{}).Contains("required"),
+			want: `error of type trial.typedErr containing "required"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Fatalf("Error() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/trial.go
+++ b/trial.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"reflect"
 	"runtime/debug"
 	"strings"
 	"testing"
@@ -211,8 +210,13 @@ func (t *Trial[In, Out]) testCase(msg string, test Case[In, Out]) result {
 		result.fail("FAIL: %q should error", msg)
 	} else if !test.ShouldErr && result.err != nil && test.ExpectedErr == nil {
 		result.fail("FAIL: %q unexpected error '%s'", msg, result.err.Error())
-	} else if test.ExpectedErr != nil && !isExpectedError(result.err, test.ExpectedErr) {
-		result.fail("FAIL: %q error %q does not match expected %q", msg, result.err, test.ExpectedErr)
+	} else if test.ExpectedErr != nil {
+		matched, matchFail := isExpectedError(result.err, test.ExpectedErr)
+		if matchFail != "" {
+			result.fail("FAIL: %q %s", msg, matchFail)
+		} else if !matched {
+			result.fail("FAIL: %q error %q does not match expected %q", msg, result.err, test.ExpectedErr)
+		}
 	} else if !test.ShouldErr && test.ExpectedErr == nil {
 		if equal, diff := t.equalFn(result.value, test.Expected); !equal {
 			result.fail("FAIL: %q \n%s", msg, diff)
@@ -238,27 +242,6 @@ func cleanStack() (s string) {
 		s += ln + "\n"
 	}
 	return s
-}
-
-func isExpectedError(actual, expected error) bool {
-	if err, ok := expected.(errCheck); ok {
-		return reflect.TypeOf(actual) == reflect.TypeOf(err.err)
-	}
-	return strings.Contains(actual.Error(), expected.Error())
-}
-
-type errCheck struct {
-	err error
-}
-
-func (e errCheck) Error() string {
-	return e.err.Error()
-}
-
-// ErrType can be used with ExpectedErr to check
-// that the expected err is of a certain type
-func ErrType(err error) error {
-	return errCheck{err}
 }
 
 type result struct {

--- a/trial_test.go
+++ b/trial_test.go
@@ -132,7 +132,7 @@ func TestTrial_TestCase(t *testing.T) {
 				return nil, testErr{}
 			}, nil),
 			Case: Case[Input, any]{
-				ExpectedErr: ErrType(testErr{}),
+				ExpectedErr: Error().IsType(testErr{}),
 			},
 			expResult: result{Success: true, Message: `PASS: "expected error of type testErr"`},
 		},
@@ -141,7 +141,7 @@ func TestTrial_TestCase(t *testing.T) {
 				return nil, nil
 			}, nil),
 			Case: Case[Input, any]{
-				ExpectedErr: ErrType(testErr{}),
+				ExpectedErr: Error().IsType(testErr{}),
 			},
 			expResult: result{Success: false, Message: `FAIL: "error type testErr with nil response"`},
 		},
@@ -150,7 +150,7 @@ func TestTrial_TestCase(t *testing.T) {
 				return nil, errors.New("some error")
 			}, nil),
 			Case: Case[Input, any]{
-				ExpectedErr: ErrType(testErr{}),
+				ExpectedErr: Error().IsType(testErr{}),
 			},
 			expResult: result{Success: false, Message: `FAIL: "error type testErr with mismatch response"`},
 		},


### PR DESCRIPTION
### Quality check

- [x] Documentation included
- [x] Test coverage

### Summary

Adds a unified `trial.Error()` builder for `ExpectedErr` matching, replacing ad-hoc `errors.New` substring checks and consolidating type/message assertions behind one API.

**Shipped API**

```go
ExpectedErr: trial.Error()                                    // any error
ExpectedErr: trial.Error().Exact("exact msg")                // full message match
ExpectedErr: trial.Error().Contains("timeout")             // substring
ExpectedErr: trial.Error().Regex(`invalid.*format`)          // regex (invalid patterns fail at compare time)
ExpectedErr: trial.Error().IsType(ValidationError{})         // type only
ExpectedErr: trial.Error().IsType(T{}).Contains("field")  // type + message
```

- New `error.go` with unexported `expectErr` sentinel; `isExpectedError` returns `(matched, failMsg)` for clear per-case failures (including invalid regex).
- `ErrType` deprecated in favor of `Error().IsType(err)`; legacy `errors.New("fragment")` substring behavior unchanged.
- Tests in `error_test.go`; docs updated in README, `docs/api.md`, `docs/examples.md`, `docs/helpers.md`.

**Design alternatives considered**

``` go 
trial.Error()                    // any error (replaces ShouldErr)
trial.Error("timeout")           // contains — migration path from errors.New
trial.Error().Exact("exact msg") // full match — explicit strict
trial.Error().Regex(`pat`)       // pattern
trial.Error().Type(T{})          // type only
```
